### PR TITLE
Add option to cycle list item markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,38 @@ The `:UpdateToc` command, which is designed to update toc manually, can only wor
 
    But then you will lose the convenience of auto update tables of contens on save and `:UpdateToc` command. When you want to update toc, you need to remove existing toc manually and rerun `:GenTocXXX` commands.
 
+3. `g:vmt_cycle_list_item_markers`
+
+   default: 0
+
+   By default, `*` is used to denote every level of a list:
+
+   ```
+   * [Level 1](#level-1)
+       * [Level 1-1](#level-1-1)
+       * [Level 1-2](#level-1-2)
+           * [Level 1-2-1](#level-1-2-1)
+   * [Level 2](level-2)
+   ```
+
+   If you set:
+
+   ```viml
+   let g:vmt_cycle_list_item_markers = 1
+   ```
+
+   every level will instead cycle between the valid list item markers `*`, `-` and `+`:
+
+   ```
+   * [Level 1](#level-1)
+       - [Level 1-1](#level-1-1)
+       - [Level 1-2](#level-1-2)
+           + [Level 1-2-1](#level-1-2-1)
+   * [Level 2](level-2)
+   ```
+
+   This renders the same according to Markdown rules, but might appeal to those who care about readability of the source.
+
 ## Screenshots
 
 * [online demo in English][5]

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -11,6 +11,10 @@ if !exists("g:vmt_dont_insert_fence")
     let g:vmt_dont_insert_fence = 0
 endif
 
+if !exists("g:vmt_cycle_list_item_markers")
+    let g:vmt_cycle_list_item_markers = 0
+endif
+
 let g:GFMHeadingIds = {}
 
 function! s:HeadingLineRegex()
@@ -164,6 +168,7 @@ endfunction
 function! s:GenToc(markdownStyle)
     let l:headingLines = <SID>GetHeadingLines()
     let l:levels = []
+    let l:listItemChars = ['*']
 
     let g:GFMHeadingIds = {}
     
@@ -177,15 +182,20 @@ function! s:GenToc(markdownStyle)
         put =<SID>GetBeginFence(a:markdownStyle)
     endif
 
+    if g:vmt_cycle_list_item_markers == 1
+        let l:listItemChars += ['-', '+']
+    endif
+
     let l:i = 0
     for headingLine in l:headingLines
         let l:headingName = <SID>GetHeadingName(headingLine)
         let l:headingIndents = l:levels[i] - l:minLevel
-
+        let l:listItemChar = l:listItemChars[(l:levels[i] + 1) % len(l:listItemChars)]
         let l:headingLink = <SID>GetHeadingLink(l:headingName, a:markdownStyle)
 
         let l:heading = repeat(s:GetIndentText(), l:headingIndents)
-        let l:heading = l:heading . "* [" . l:headingName . "]"
+        let l:heading = l:heading . l:listItemChar
+        let l:heading = l:heading . " [" . l:headingName . "]"
         let l:heading = l:heading . "(#" . l:headingLink . ")"
 
         put =l:heading


### PR DESCRIPTION
The new option `g:vmt_cycle_list_item_markers` (default: 0, enable: 1) will if enabled use different list item markers depending on the list item level, cycling between the allowed and equivalent characters `*`,
`-` and `+` [0, 1].

This should render the same using any Markdown parser, but intends to be more readable when looking at the TOC in raw text form.

0: https://daringfireball.net/projects/markdown/syntax#list
1: http://spec.commonmark.org/0.27/#bullet-list-marker