### PR TITLE
Add accentuated latin1 chars

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -106,7 +106,7 @@ function! s:GetHeadingLinkGFM(headingName)
     let l:headingLink = tolower(a:headingName)
 
     let l:headingLink = substitute(l:headingLink, "\\%^_\\+\\|_\\+\\%$", "", "g")
-    let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u4e00-\u9fbf _-]", "", "g")
+    let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u00C0-\u00FF\u4e00-\u9fbf _-]", "", "g")
     let l:headingLink = substitute(l:headingLink, " ", "-", "g")
 
     if l:headingLink ==# ""

--- a/test/test.vim
+++ b/test/test.vim
@@ -38,6 +38,7 @@ call ASSERT(GetHeadingLinkTest("### [vim-markdown-toc-again][1]", "GFM") ==# "vi
 call ASSERT(GetHeadingLinkTest("### ![vim-markdown-toc-img](/path/to/a/png)", "GFM") ==# "vim-markdown-toc-img")
 call ASSERT(GetHeadingLinkTest("### ![](/path/to/a/png)", "GFM") ==# "-2")
 call ASSERT(GetHeadingLinkTest("### 1.1", "GFM") ==# "11")
+call ASSERT(GetHeadingLinkTest("### heading with some \"special\" \(yes, special\) chars: les caractères unicodes", "GFM") ==# "heading-with-some-special-yes-special-chars-les-caractères-unicodes")
 
 " Redcarpet Test Cases
 call ASSERT(GetHeadingLinkTest("# -Hello-World-", "Redcarpet") ==# "hello-world")


### PR DESCRIPTION
Github adds links with accentuated characters. Your regex was a bit too much restrictive in this regard, breaking my links in the process.

French speaking users of your plugin will appreciate.

For sure, other characters classes should be added to this regex, but we do not know how the Github GFM parser creates its transliteration rules (unless we do? I don't think their code is FOSS though).

For people who do not want to merge this: the already merged character class `\u4e00-\u9fbf` contains Asian chars which as per [RFC 1738](https://www.ietf.org/rfc/rfc1738.txt) are not standard as well since URLs should only contain ASCII chars (unless URL encoded).

Regards,