### PR TITLE
Fix Cyrillic for GitLab

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -150,10 +150,10 @@ endfunction
 " suppport for GitLab, fork of GetHeadingLinkGFM
 " it's dirty to copy & paste code but more clear for maintain
 function! s:GetHeadingLinkGitLab(headingName)
-    let l:headingLink = tolower(a:headingName)
+    let l:headingLink = tr(a:headingName, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
 
     let l:headingLink = substitute(l:headingLink, "\\_^_\\+\\|_\\+\\_$", "", "g")
-    let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u00C0-\u00FF\u4e00-\u9fbf _-]", "", "g")
+    let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u00C0-\u00FF\u0400-\u04ff\u4e00-\u9fbf _-]", "", "g")
     let l:headingLink = substitute(l:headingLink, " ", "-", "g")
     let l:headingLink = substitute(l:headingLink, "-\\{2,}", "-", "g")
 


### PR DESCRIPTION
Current (10.1.4) GitLab doesn't turn Cyrillic anchors to lower case, so I suppose it convert to lower case only ASCII, but I have not tested this.