### PR TITLE
Add tests for Marked style toc.

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -204,14 +204,7 @@ endfunction
 function! s:GetHeadingLinkMarked(headingName)
     let l:headingLink = tolower(a:headingName)
 
-    let l:headingLink = substitute(l:headingLink, "<[^>]\\+>", "", "g")
-    let l:headingLink = substitute(l:headingLink, "&", "&amp;", "g")
-    let l:headingLink = substitute(l:headingLink, "\"", "&quot;", "g")
-    let l:headingLink = substitute(l:headingLink, "'", "&#39;", "g")
-
-    let l:headingLink = substitute(l:headingLink, "[ \\-&+\\$,/:;=?@\"#{}|\\^\\~\\[\\]`\\*()%!']\\+", "-", "g")
-    let l:headingLink = substitute(l:headingLink, "-\\{2,}", "-", "g")
-    let l:headingLink = substitute(l:headingLink, "\\%^[\\-_]\\+\\|[\\-_]\\+\\%$", "", "g")
+    let l:headingLink = substitute(l:headingLink, "[ ]\\+", "-", "g")
 
     return l:headingLink
 endfunction

--- a/test/Marked.md
+++ b/test/Marked.md
@@ -1,0 +1,173 @@
+# Hi There ~
+
+<!-- vim-markdown-toc Marked -->
+
+* [Chapter One Basics ~](#chapter-one-basics-~)
+    * [Section 1.1 Introduction](#section-1.1-introduction)
+* [Chapter Two Test More](#chapter-two-test-more)
+    * [Section 2.1 Don't Do This!](#section-2.1-don't-do-this!)
+    * [Section 2.2 If you meet problem please contact bardongong@163.com](#section-2.2-if-you-meet-problem-please-contact-bardongong@163.com)
+    * [Section 2.3 Do you know `Vim`?](#section-2.3-do-you-know-`vim`?)
+    * [Section 2.4 Carefully Use 'Symbol $' & "Symbol %"](#section-2.4-carefully-use-'symbol-$'-&-"symbol-%")
+    * [Section 2.5 When you write < means small, > means big](#section-2.5-when-you-write-<-means-small,->-means-big)
+* [Chapter Three End of Tests](#chapter-three-end-of-tests)
+    * [Section 3.1 Can I use /? || \?](#section-3.1-can-i-use-/?-||-\?)
+    * [Section 3.2 Test @ and -](#section-3.2-test-@-and--)
+    * [Section 3.3 Done. Cheer Up~](#section-3.3-done.-cheer-up~)
+
+<!-- vim-markdown-toc -->
+
+> Actually, Marked.js replace all none "\w" characters to "-", however,
+> iamcco/markdown-preview.vim replace only "\s" characters "-", make it
+> clear, the rule here is for the later one.
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+Let's fill some lines here ~~~
+
+## Chapter One Basics ~
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+### Section 1.1 Introduction  
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+Let's fill some lines here for Basics ~~~
+
+## Chapter Two Test More
+
+Let's fill some lines here for more tests ~~~
+
+Let's fill some lines here for more tests ~~~
+
+### Section 2.1 Don't Do This!
+
+Let's fill some lines here for more tests ~~~
+
+Let's fill some lines here for more tests ~~~
+
+Let's fill some lines here for more tests ~~~
+
+### Section 2.2 If you meet problem please contact bardongong@163.com
+
+Let's fill some lines here for more tests ~~~
+
+Let's fill some lines here for more tests ~~~
+
+Let's fill some lines here for more tests ~~~
+
+### Section 2.3 Do you know `Vim`?
+
+Let's fill some lines here for more tests ~~~
+
+### Section 2.4 Carefully Use 'Symbol $' & "Symbol %" 
+
+Let's fill some lines here for more tests ~~~
+
+### Section 2.5 When you write < means small, > means big
+
+Let's fill some lines here for more tests ~~~
+
+## Chapter Three End of Tests
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+### Section 3.1 Can I use /? || \?
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+Let's fill some lines here for end of tests ~~~
+
+### Section 3.2 Test @ and - 
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+
+That's all thx.
+
+### Section 3.3 Done. Cheer Up~
+
+YES! YOU CAN DO ALL OF ThOSE THINGS!
+

--- a/test/test.vim
+++ b/test/test.vim
@@ -77,4 +77,11 @@ call ASSERT(GetHeadingLinkTest("###### '你好'世界'", "Redcarpet") ==# "39-�
 call ASSERT(GetHeadingLinkTest("# &你好&世界&", "Redcarpet") ==# "amp-你好-amp-世界-amp")
 call ASSERT(GetHeadingLinkTest("## `-ms-text-autospace` to the rescue?", "Redcarpet") ==# "ms-text-autospace-to-the-rescue")
 
+"
+" Marked Test Cases {{{
+call ASSERT(GetHeadingLinkTest("# Book", "Marked") ==# "Book")
+call ASSERT(GetHeadingLinkTest("# Chapter One Introduction", "Marked") ==# "Chapter-One-Introduction")
+call ASSERT(GetHeadingLinkTest("## Section 1.2 Beginners", "Marked") ==# "Section-1.2-Beginners")
+" }}}
+
 echo "" . g:passCaseCount . " cases pass, " . g:errorCaseCount . " cases error"


### PR DESCRIPTION
I read part of the source code of markdown-preview and marked.js, then I modified the regex for Marked style ToC.

And , I try to write test cases to test.vim, but there is always errors(I guess the way to execute is `:source test.vim`, if it's not please tell me ^_^).  At last, I write another sample file `Marked.md` instead.  