### PR TITLE
Add support for closing fence text and hidden markdown style

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,13 @@ The `:UpdateToc` command, which is designed to update toc manually, can only wor
    <!-- /TOC -->
    ```
 
-5. `g:vmt_cycle_list_item_markers`
+5. `g:vmt_fence_hidden_markdown_style`
+
+   default: `''`
+
+   By default, _vim-markdown-toc_ will add the markdown style into the fence of the text for the table of contents. You can avoid this and set a default markdown style with `g:vmt_fence_hidden_markdown_style` that is applied if a fence is found containing the `g:vmt_fence_text` without any markdown style. Obviously, `g:vmt_fence_hidden_markdown_style` has to be supported, i.e. currently one of `['GFM', 'Redcarpet', 'GitLab', 'Marked']`.
+
+6. `g:vmt_cycle_list_item_markers`
 
    default: 0
 
@@ -168,7 +174,7 @@ The `:UpdateToc` command, which is designed to update toc manually, can only wor
 
    This renders the same according to Markdown rules, but might appeal to those who care about readability of the source.
 
-6. `g:vmt_list_item_char`
+7. `g:vmt_list_item_char`
 
     default: `*`
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,25 @@ The `:UpdateToc` command, which is designed to update toc manually, can only wor
 
    But then you will lose the convenience of auto update tables of contents on save and `:UpdateToc` command. When you want to update toc, you need to remove existing toc manually and rerun `:GenTocXXX` commands.
 
-3. `g:vmt_cycle_list_item_markers`
+3. `g:vmt_fence_text`
+
+   default: `vim-markdown-toc`
+
+   Inner text of the fence marker for the table of contents, see `g:vmt_dont_insert_fence`.
+
+4. `g:vmt_fence_closing_text`
+
+   default: `g:vmt_fence_text`
+
+   Inner text of the closing fence marker. E.g., you could `let g:vmt_fence_text = 'TOC'` and `let g:vmt_fence_closing_text = '/TOC'` to get
+
+   ```
+   <!-- TOC -->
+   [TOC]
+   <!-- /TOC -->
+   ```
+
+5. `g:vmt_cycle_list_item_markers`
 
    default: 0
 
@@ -150,7 +168,7 @@ The `:UpdateToc` command, which is designed to update toc manually, can only wor
 
    This renders the same according to Markdown rules, but might appeal to those who care about readability of the source.
 
-4. `g:vmt_list_item_char`
+6. `g:vmt_list_item_char`
 
     default: `*`
 

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -22,6 +22,10 @@ if !exists("g:vmt_fence_closing_text")
     let g:vmt_fence_closing_text = g:vmt_fence_text
 endif
 
+if !exists("g:vmt_fence_hidden_markdown_style")
+    let g:vmt_fence_hidden_markdown_style = ''
+endif
+
 if !exists("g:vmt_list_item_char")
     let g:vmt_list_item_char = '*'
 endif
@@ -333,7 +337,7 @@ function! s:GetBeginFencePattern(isModeline)
     if a:isModeline != 0
         return "<!-- " . g:vmt_fence_text . " -->"
     else
-        return "<!-- " . g:vmt_fence_text . " \\([[:alpha:]]\\+\\) -->"
+        return "<!-- " . g:vmt_fence_text . " \\([[:alpha:]]\\+\\)\\? \\?-->"
     endif
 endfunction
 
@@ -420,9 +424,20 @@ function! s:DeleteExistingToc()
                 let l:markdownStyle = matchlist(l:beginLine, l:tocBeginPattern)[1]
             endif
 
+            let l:doDelete = 0
             if index(s:supportMarkdownStyles, l:markdownStyle) == -1
-                let l:markdownStyle = "Unknown"
+                if l:markdownStyle ==# "" && index(s:supportMarkdownStyles, g:vmt_fence_hidden_markdown_style) != -1
+                    let l:markdownStyle = g:vmt_fence_hidden_markdown_style
+                    let l:isModeline = 1
+                    let l:doDelete = 1
+                else
+                    let l:markdownStyle = "Unknown"
+                endif
             else
+                let l:doDelete = 1
+            endif
+
+            if l:doDelete == 1
                 let l:endLineNumber = line(".")
                 silent execute l:beginLineNumber. "," . l:endLineNumber. "delete_"
             end

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -18,6 +18,10 @@ if !exists("g:vmt_fence_text")
     let g:vmt_fence_text = 'vim-markdown-toc'
 endif
 
+if !exists("g:vmt_fence_closing_text")
+    let g:vmt_fence_closing_text = g:vmt_fence_text
+endif
+
 if !exists("g:vmt_list_item_char")
     let g:vmt_list_item_char = '*'
 endif
@@ -315,26 +319,26 @@ endfunction
 
 function! s:GetBeginFence(markdownStyle, isModeline)
     if a:isModeline != 0
-        return <SID>GetEndFence()
+        return "<!-- " . g:vmt_fence_text . " -->"
     else
         return "<!-- ". g:vmt_fence_text . " " . a:markdownStyle . " -->"
     endif
 endfunction
 
 function! s:GetEndFence()
-    return "<!-- " . g:vmt_fence_text . " -->"
+    return "<!-- " . g:vmt_fence_closing_text . " -->"
 endfunction
 
 function! s:GetBeginFencePattern(isModeline)
     if a:isModeline != 0
-        return <SID>GetEndFencePattern()
+        return "<!-- " . g:vmt_fence_text . " -->"
     else
         return "<!-- " . g:vmt_fence_text . " \\([[:alpha:]]\\+\\) -->"
     endif
 endfunction
 
 function! s:GetEndFencePattern()
-    return <SID>GetEndFence()
+    return "<!-- " . g:vmt_fence_closing_text . " -->"
 endfunction
 
 function! s:GetMarkdownStyleInModeline()


### PR DESCRIPTION
**Add vmt_fence_closing_text**

There are other editors that create TOCs together with corresponding
marks. Some of them add additional strings to the closing mark, e.g.
for the opening fence mark `TOC` they use `/TOC` for the closing mark.

With vmt_fence_closing_text it is now possible to adapt to this
situation.


**Add hidden markdown style**

If you do not want to have markdown style appear in fence for table of
contents you can now set a default markdown style that is applied if the
main fence text is found but a markdown style is missing within the
fence. Set `g:vmt_fence_hidden_markdown_style` to a markdown style that is
supported, i.e. `g:supportMarkdownStyles` should contain
`g:vmt_fence_hidden_markdown_style`.