### PR TITLE
add mdx to acceptable file types

### DIFF
--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,1 +1,1 @@
-au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn} set filetype=markdown
+au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn,mdx} set filetype=markdown


### PR DESCRIPTION
MDX files are used by [mdxjs](https://mdxjs.com/) to designate files that possibly contain JSX and which are then processed. This change allows vim-markdown-toc to work with that extension. I tested this and it worked without problem.