### PR TITLE
Add a range of Kana characters

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -155,7 +155,7 @@ function! s:GetHeadingLinkGFM(headingName)
     " chinese chars are removed.
     " \\%#=0: allow this pattern to use the regexp engine he wants. Having
     " `set re=1` in the vimrc could break this behavior. cf. issue #19
-    let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u00C0-\u00FF\u0400-\u04ff\u4e00-\u9fbf _-]", "", "g")
+    let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u00C0-\u00FF\u0400-\u04ff\u4e00-\u9fbf\u3040-\u309F\u30A0-\u30FF _-]", "", "g")
     let l:headingLink = substitute(l:headingLink, " ", "-", "g")
 
     if l:headingLink ==# ""


### PR DESCRIPTION
Hi, Thanks for the great plugin.

In the Japanese language, the characters are called "Kana" characters. For example, the famous character Hatsune Miku.

I hope this plugin also supports Kana characters.

Before:

```markdown
# About Hatsune Miku

<!-- vim-markdown-toc GFM -->

* [初音ミクV3について](#初音v3)

<!-- vim-markdown-toc -->

## 初音ミクV3について
```

After:

```markdown
# About Hatsune Miku

<!-- vim-markdown-toc GFM -->

* [初音ミクV3について](#初音ミクv3について)

<!-- vim-markdown-toc -->

## 初音ミクV3について
````