### PR TITLE
Keep Korean syllables

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -152,10 +152,10 @@ function! s:GetHeadingLinkGFM(headingName)
     " \_$ : end of line
     let l:headingLink = substitute(l:headingLink, "\\_^_\\+\\|_\\+\\_$", "", "g")
     " Characters that are not alphanumeric, latin1 extended (for accents) and
-    " chinese chars are removed.
+    " chinese/korean chars are removed.
     " \\%#=0: allow this pattern to use the regexp engine he wants. Having
     " `set re=1` in the vimrc could break this behavior. cf. issue #19
-    let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u00C0-\u00FF\u0400-\u04ff\u4e00-\u9fbf\u3040-\u309F\u30A0-\u30FF _-]", "", "g")
+    let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u00C0-\u00FF\u0400-\u04ff\u4e00-\u9fbf\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF _-]", "", "g")
     let l:headingLink = substitute(l:headingLink, " ", "-", "g")
 
     if l:headingLink ==# ""

--- a/test/test.vim
+++ b/test/test.vim
@@ -40,6 +40,7 @@ call ASSERT(GetHeadingLinkTest("### ![](/path/to/a/png)", "GFM") ==# "-2")
 call ASSERT(GetHeadingLinkTest("### 1.1", "GFM") ==# "11")
 call ASSERT(GetHeadingLinkTest("### heading with some \"special\" \(yes, special\) chars: les caractères unicodes", "GFM") ==# "heading-with-some-special-yes-special-chars-les-caractères-unicodes")
 call ASSERT(GetHeadingLinkTest("## 初音ミクV3について", "GFM") ==# "初音ミクv3について")
+call ASSERT(GetHeadingLinkTest("# 안녕", "GFM") ==# "안녕")
 " }}}
 
 " GitLab Test Cases {{{


### PR DESCRIPTION
Hi, thanks for the project.

This pull request updates `:GenTocGFM` to keep Korean letters as well.

Reference: https://en.wikipedia.org/wiki/Hangul_Syllables

> Range | U+AC00..U+D7AF(11,184 code points)