### PR TITLE
Fix gitlab style issue with heading that starts with Cyrillic

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -192,8 +192,8 @@ endfunction
 " suppport for GitLab, fork of GetHeadingLinkGFM
 " it's dirty to copy & paste code but more clear for maintain
 function! s:GetHeadingLinkGitLab(headingName)
-    let l:headingLink = tr(a:headingName, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
-
+    let l:headingLink = tolower(a:headingName)
+  
     let l:headingLink = substitute(l:headingLink, "\\_^_\\+\\|_\\+\\_$", "", "g")
     let l:headingLink = substitute(l:headingLink, "\\%#=0[^[:alnum:]\u00C0-\u00FF\u0400-\u04ff\u4e00-\u9fbf _-]", "", "g")
     let l:headingLink = substitute(l:headingLink, " ", "-", "g")

--- a/test/test.vim
+++ b/test/test.vim
@@ -67,7 +67,8 @@ call ASSERT(GetHeadingLinkTest("### ![vim-markdown-toc-img](/path/to/a/png)", "G
 call ASSERT(GetHeadingLinkTest("### ![](/path/to/a/png)", "GitLab") ==# "-2")
 call ASSERT(GetHeadingLinkTest("### 1.1", "GitLab") ==# "11")
 call ASSERT(GetHeadingLinkTest("### heading with some \"special\" \(yes, special\) chars: les caractères unicodes", "GitLab") ==# "heading-with-some-special-yes-special-chars-les-caractères-unicodes")
-call ASSERT(GetHeadingLinkTest("## heading with Cyrillic Б б", "GitLab") ==# "heading-with-cyrillic-Б-б")
+call ASSERT(GetHeadingLinkTest("## heading with Cyrillic Б б", "GitLab") ==# "heading-with-cyrillic-б-б")
+call ASSERT(GetHeadingLinkTest("## Ю heading starts with Cyrillic", "GitLab") ==# "ю-heading-starts-with-cyrillic")
 " }}}
 
 " Redcarpet Test Cases {{{


### PR DESCRIPTION
If heading starts with upperscase Cyrillic, links doesn't work when viewed in gitlab
