### PR TITLE
Remove filetype detection

### DIFF
--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,1 +1,0 @@
-au BufRead,BufNewFile *.{md,mdown,mkd,mkdn,markdown,mdwn,mdx} set filetype=markdown


### PR DESCRIPTION
Vim has built-in markdown filetype detection, so adding `au BufRead,BufNewFile` sets the filetype for a second time, evaluating indent, syntax, etc, which can make loading markdown files very slow.

An alternative might be to use `setfiletype` instead ([`:help :setfiletype`](https://vimhelp.org/options.txt.html#%3Asetfiletype)) to make sure it only gets set once, but in general, I don't think a plugin that adds functionality to a markdown file should need to set the filetype itself.